### PR TITLE
add default tab setting and partial fix when localization is used

### DIFF
--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -62,6 +62,11 @@ onUiLoaded(function() {
   }
 });
 
+function getText_ExtraNetworksSidePanel(text) {
+    let tl = getTranslation(text);
+    return tl !== undefined ? tl.trim() : text.trim();
+}
+
 function rsen_toggleExtraNetworks() {
 	// Get all the elements you are interested in and put them into an object to make the later code a bit cleaner
 	let settingsObjects = [
@@ -91,19 +96,20 @@ function rsen_toggleExtraNetworks() {
 		// Loop through each object in the array we created earlier
 		settingsObjects.forEach(obj => {
 			// Find the tab buttons with the text "Checkpoints" and "Generation"
-			let checkpointsButton = Array.from(obj.tab_nav.querySelectorAll('button')).find(button => button.innerHTML.trim() === opts.extra_networks_side_panel_default_tab);
-			let generationButton = Array.from(obj.tab_nav.querySelectorAll('button')).find(button => button.innerHTML.trim() === "Generation");
+            let tabButtons = Array.from(obj.tab_nav.querySelectorAll('button'))
+			let defaultTabButton = tabButtons.find(button => button.innerHTML.trim() === getText_ExtraNetworksSidePanel(opts.extra_networks_side_panel_default_tab));
+			let generationButton = tabButtons.find(button => button.innerHTML.trim() === getText_ExtraNetworksSidePanel("Generation"));
       
 			let lastTabButton;
       if (typeof obj.lastTabButton !== "undefined") {
         lastTabButton = Array.from(obj.tab_nav.querySelectorAll('button')).find(button => button.innerHTML.trim() === obj.lastTabButton.innerHTML.trim());
       }
 
-			if (checkpointsButton && generationButton) {
+			if (defaultTabButton && generationButton) {
 				if (!rsen_toggleState) {
           if (typeof lastTabButton === "undefined") {
 					  // Click the "Checkpoints" tab button
-					  checkpointsButton.click();
+					  defaultTabButton.click();
           } else {
             // Switch to the last tab open
             lastTabButton.click();
@@ -193,11 +199,11 @@ function rsen_toggleExtraNetworks() {
 onUiUpdate(function(args) {
   const lastTxt2imgTabButton = document.querySelector("#txt2img_extra_tabs > .tab-nav > .selected");
   const lastImg2imgTabButton = document.querySelector("#img2img_extra_tabs > .tab-nav > .selected");
-
-  if(lastTxt2imgTabButton != null && typeof lastTxt2imgTabButton !== "undefined" && lastTxt2imgTabButton.innerHTML.trim() !== "Generation") {
+  let generationText = getText_ExtraNetworksSidePanel("Generation")
+  if(lastTxt2imgTabButton != null && typeof lastTxt2imgTabButton !== "undefined" && lastTxt2imgTabButton.innerHTML.trim() !== generationText) {
     rsen_lastTxt2imgTabButton = lastTxt2imgTabButton;
   }
-  if(lastImg2imgTabButton != null && typeof lastImg2imgTabButton !== "undefined" && lastImg2imgTabButton.innerHTML.trim() !== "Generation") {
+  if(lastImg2imgTabButton != null && typeof lastImg2imgTabButton !== "undefined" && lastImg2imgTabButton.innerHTML.trim() !== generationText) {
     rsen_lastImg2imgTabButton = lastImg2imgTabButton;
   }
 });

--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -91,7 +91,7 @@ function rsen_toggleExtraNetworks() {
 		// Loop through each object in the array we created earlier
 		settingsObjects.forEach(obj => {
 			// Find the tab buttons with the text "Checkpoints" and "Generation"
-			let checkpointsButton = Array.from(obj.tab_nav.querySelectorAll('button')).find(button => button.innerHTML.trim() === "Checkpoints");
+			let checkpointsButton = Array.from(obj.tab_nav.querySelectorAll('button')).find(button => button.innerHTML.trim() === opts.extra_networks_side_panel_default_tab);
 			let generationButton = Array.from(obj.tab_nav.querySelectorAll('button')).find(button => button.innerHTML.trim() === "Generation");
       
 			let lastTabButton;

--- a/scripts/extra_network_side_panel_for_a1111.py
+++ b/scripts/extra_network_side_panel_for_a1111.py
@@ -1,0 +1,22 @@
+from modules import script_callbacks, ui_extra_networks, shared
+import gradio as gr
+
+
+def on_ui_settings():
+    section = ('extra_networks', 'Extra Networks')
+    page_titles = [page.title for page in ui_extra_networks.extra_pages]
+    shared.opts.add_option(
+        'extra_networks_side_panel_default_tab',
+        shared.OptionInfo(
+            page_titles[0],
+            'Extra networks side panel default tab',
+            gr.Radio,
+            {
+                'choices': page_titles,
+            },
+            section=section
+        ).info('The default tab that is selected when opening the extra networks side panel')
+    )
+
+
+script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
@CurtisDS 

> [By default it will open the Checkpoint tab if you haven't opened a tab yet. If I were to try and make the default tab a configurable setting Id need to know what extra network tabs are available on the python side. I don't know an easy way of getting that list because extensions can add tabs.](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/352#issuecomment-2248364076)

it's actually not that hard here is an implementation

I added a setting radio menu at Setting > Extra Networks > Extra networks side panel default tab
![image](https://github.com/user-attachments/assets/53538df5-2d9f-437b-8ce5-d82bf6f25de3)

default is set the the first item which should be Textual Inversion
if you want to change the default to something else go ahead but if you're going to send it to `Lora` then you should check if the Lora is in that `page_titles` because remember Lora is technically an extension so it can be disabled

---

when working on a boat I also noticed that since you're directly comparing the `innerHTML` with specific strings this raises a potential issues when localization is used

I was only able to partially fix this (I'm not a web dev)

before the fix when localization is used nothing happens
after the fix it at least opens the side panel but it doesn't switch to the tab

I was testing with localization https://github.com/harukaxxxx/stable-diffusion-webui-localization-zh_TW whitch replaces the 
> localization is a built-in function of web UI, but the localization file needs to be instell like an extension

see Setting > User interface > localization 

> I'm not a web dev so I'm not sure if there is a better way of fixing this other than getting the string of the localization dict
